### PR TITLE
fix: use correct source workspace name in From reference

### DIFF
--- a/pkg/services/forkspacer/workspace.go
+++ b/pkg/services/forkspacer/workspace.go
@@ -150,7 +150,7 @@ func (s ForkspacerWorkspaceService) Create(
 
 	if workspaceIn.From != nil {
 		workspace.Spec.From = &batchv1.WorkspaceFromReference{
-			Name:      workspaceIn.Name,
+			Name:      workspaceIn.From.Name,
 			Namespace: workspaceIn.From.Namespace,
 		}
 	}


### PR DESCRIPTION
Fixed create new workspace from exisiting-workspace ... (object (WorkspaceResourceReference))

```
{
  "name": "my-new-workspace",
  "from": {
    "name": "existing-workspace",
    "namespace": "default"
  },
  "connection": {"type": "in-cluster"},
  "hibernated": false
}

```

works now ...