### PR TITLE
feat: add type and workspace fields to module list response

### DIFF
--- a/pkg/api/v1/handlers/module.go
+++ b/pkg/api/v1/handlers/module.go
@@ -222,7 +222,7 @@ func (h ModuleHandler) ListHandle(w http.ResponseWriter, r *http.Request) {
 		// Extract module type from source
 		moduleType := "Unknown"
 		if module.Spec.Source.Raw != nil && len(module.Spec.Source.Raw.Raw) > 0 {
-			var sourceData map[string]interface{}
+			var sourceData map[string]any
 			if err := json.Unmarshal(module.Spec.Source.Raw.Raw, &sourceData); err == nil {
 				if kind, ok := sourceData["kind"].(string); ok {
 					moduleType = kind

--- a/pkg/api/v1/handlers/module.go
+++ b/pkg/api/v1/handlers/module.go
@@ -222,7 +222,6 @@ func (h ModuleHandler) ListHandle(w http.ResponseWriter, r *http.Request) {
 		// Extract module type from source
 		moduleType := "Unknown"
 		if module.Spec.Source.Raw != nil && len(module.Spec.Source.Raw.Raw) > 0 {
-			// Parse the raw JSON to extract the kind field
 			var sourceData map[string]interface{}
 			if err := json.Unmarshal(module.Spec.Source.Raw.Raw, &sourceData); err == nil {
 				if kind, ok := sourceData["kind"].(string); ok {


### PR DESCRIPTION
- Add workspace reference field to module list items
- Extract and return module type (Helm, Custom, Remote) from source
- Parse source.raw.kind field to determine module type