### PR TITLE
fix: update release workflow to trigger on release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release - Build and Push Image
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [created]
 
 permissions:
   contents: write
@@ -69,7 +68,7 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -94,23 +93,3 @@ jobs:
               "version": "${{ env.VERSION }}",
               "chart_version": "${{ env.CHART_VERSION }}"
             }
-
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.VERSION }}
-          release_name: Release ${{ env.VERSION }}
-          body: |
-            ## Docker Image
-
-            ```
-            docker pull ${{ env.IMAGE_REPO }}:${{ env.VERSION }}
-            ```
-
-            ## Installation
-
-            See the [documentation](https://github.com/forkspacer/api-server#installation) for installation instructions.
-          draft: false
-          prerelease: false


### PR DESCRIPTION
- Change trigger from tag push to release creation to avoid circular dependency
- Remove deprecated create-release step since release is now created first
- Clean up whitespace